### PR TITLE
Support for local STIX objects

### DIFF
--- a/attackcti/attack_api.py
+++ b/attackcti/attack_api.py
@@ -39,9 +39,6 @@ class attack_client(object):
             self.TC_PRE_SOURCE = FileSystemSource(os.path.join(local_path, PRE_ATTCK_LOCAL_DIR))
             self.TC_MOBILE_SOURCE = FileSystemSource(os.path.join(local_path, MOBILE_ATTCK_LOCAL_DIR))
         else:
-            local_path = None
-
-        if local_path is None:
             ENTERPRISE_COLLECTION = Collection(ATTCK_STIX_COLLECTIONS + ENTERPRISE_ATTCK + "/")
             PRE_COLLECTION = Collection(ATTCK_STIX_COLLECTIONS + PRE_ATTCK + "/")
             MOBILE_COLLECTION = Collection(ATTCK_STIX_COLLECTIONS + MOBILE_ATTCK + "/")


### PR DESCRIPTION
Added constructor and local_path parameter to attack_client class in order to support the use of local STIX objects. Implemented some checks to verify if the given local path exists and is indeed a local STIX directory with ATT&CK objects (see https://github.com/mitre/cti). If the checks fail, it falls back to the content of the online TAXII server.