### PR TITLE
import taxii2client.V20 issue fixed

### DIFF
--- a/attackcti/attack_api.py
+++ b/attackcti/attack_api.py
@@ -11,7 +11,7 @@
 
 from stix2 import TAXIICollectionSource, Filter, CompositeDataSource, FileSystemSource
 from stix2.utils import get_type_from_id
-from taxii2client.v20 import Collection
+from taxii2client import Collection
 import json
 import os
 


### PR DESCRIPTION
import from taxii2client.V20 is currently not functional. 
Use import from taxii2client instead.