### PR TITLE
New function to remove deprecated STIX objects

### DIFF
--- a/attackcti/attack_api.py
+++ b/attackcti/attack_api.py
@@ -246,6 +246,17 @@ class attack_client(object):
                     continue
             handle_revoked.append(obj)
         return handle_revoked
+    
+    def remove_deprecated(self, stix_objects, extract=False):
+        handle_deprecated = list()
+        for obj in stix_objects:
+            if 'x_mitre_deprecated' in obj.keys() and obj['x_mitre_deprecated'] == True:
+                if extract:
+                    handle_deprecated.append(obj)
+                else:
+                    continue
+            handle_deprecated.append(obj)
+        return handle_deprecated
 
     # ******** Enterprise ATT&CK Technology Domain  *******
     def get_enterprise(self, stix_format=True):


### PR DESCRIPTION
Hi Roberto,

While we were busy with adding support for sub-techniques in DeTT&CT we noticed that we needed to get rid of STIX objects that are deprecated. In our particular case, these were old techniques which are no longer used in the latest release of ATT&CK. I have therefore added a new function based on the already existing function `remove_revoked`. The new function `remove_deprecated` removes any objects which have the STIX property 'x_mitre_deprecated' set to `true`

I think it would be of value to add this to attackcti.

Regards,
Marcus